### PR TITLE
+ add support to stopwatch activity by checking not None distance

### DIFF
--- a/gcexport.py
+++ b/gcexport.py
@@ -439,7 +439,7 @@ while total_downloaded < total_to_download:
 			print hhmmssFromSeconds(a['duration']) + ',',
 		else:
 			print '??:??:??,',
-		if 'distance' in a:
+		if 'distance' in a and a['distance']:
 			print "{0:.3f}".format(a['distance']/1000)
 		else:
 			print '0.000 km'


### PR DESCRIPTION
Stopwacth actity with u'activityType': {u'typeId': 151, u'typeKey': u'stop_watch', u'parentTypeId': 4, u'sortOrder': 79} has field "distance" but it's set to None so the operation a['distance']/1000 throws a NoneType and Int unsuported operand types.

stack:
Traceback (most recent call last):
  File "./gcexport.py", line 443, in <module>
    print "{0:.3f}".format(a['distance']/1000)
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'


