### PR TITLE
Fix HTTP Error 402: Payment Required

### DIFF
--- a/gcexport.py
+++ b/gcexport.py
@@ -72,6 +72,7 @@ def http_req(url, post=None, headers={}):
 	# request.add_header('User-Agent', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/1337 Safari/537.36')  # Tell Garmin we're some supported browser.
 	request.add_header('User-Agent', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2816.0 Safari/537.36')  # Tell Garmin we're some supported browser.
 	request.add_header('origin', 'https://sso.garmin.com') #this new header is needed after recent changes made by Garmin
+	request.add_header('NK', 'NT') #this new header is needed after recent changes made by Garmin to prevent HTTP Error 402: Payment Required
 	for header_key, header_value in headers.iteritems():
 		request.add_header(header_key, header_value)
 	if post:


### PR DESCRIPTION
This PR fixes the following issue that started to happen today (25-fev-2021):
```
https://connect.garmin.com/modern/proxy/activitylist-service/activities/search/activities?start=0&limit=1000
Traceback (most recent call last):
  File "./gcexport.py", line 380, in <module>
    result = http_req(url_gc_search + urlencode(search_params))
  File "./gcexport.py", line 84, in http_req
    response = opener.open(request, data=post)  # This line may throw a urllib2.HTTPError.
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 435, in open
    response = meth(req, response)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 548, in http_response
    'http', request, response, code, msg, hdrs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 473, in error
    return self._call_chain(*args)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 556, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
urllib2.HTTPError: HTTP Error 402: Payment Required
```

by adding a new `NK` header with value `NT`.